### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/eventoL/eventoL-auth.png?label=ready&title=Ready)](https://waffle.io/eventoL/eventoL-auth)
 # eventoL-auth
 Authenticate and link oauth2 profiles.
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/eventoL/eventoL-auth

This was requested by a real person (user AgustinCroce) on waffle.io, we're not trying to spam you.
